### PR TITLE
feat: added progress indicator at the start of create

### DIFF
--- a/eksup/Cargo.toml
+++ b/eksup/Cargo.toml
@@ -31,6 +31,7 @@ aws-sdk-autoscaling = "0.25"
 aws-sdk-ec2 = "0.25"
 aws-sdk-eks = "0.25"
 aws-types = "0.55"
+indicatif = "0.16.2"
 clap = { version = "4.0", features = ["derive", "string"] }
 clap-verbosity-flag = "2.0"
 handlebars = { version = "4.3", features = ["rust-embed"] }

--- a/eksup/src/progress.rs
+++ b/eksup/src/progress.rs
@@ -1,0 +1,24 @@
+use indicatif::{ProgressBar, ProgressStyle};
+
+pub struct ProgressTracker {
+    progress_bar: ProgressBar,
+}
+
+impl ProgressTracker {
+    pub fn new() -> Self {
+        let progress_bar = ProgressBar::new(100);
+        progress_bar.set_style(ProgressStyle::default_bar()
+            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {percent}% ({eta})")
+            .progress_chars("=> "));
+
+        Self { progress_bar }
+    }
+
+    pub fn set_progress(&self, progress: u8) {
+        self.progress_bar.set_position(progress as u64);
+    }
+
+    pub fn finish(&self) {
+        self.progress_bar.finish();
+    }
+}


### PR DESCRIPTION
## Description
This PR adds a progress indicator to the eksup CLI tool to provide users with a 
better understanding of the progress of the analyze and create operations. We are 
using the indicatif crate to implement the progress indicator. Here is a summary of 
the changes and considerations:

A new ProgressTracker struct is implemented in a separate progress.rs module. This 
struct handles creating and updating the progress bar based on the percentage of 
progress made.

The progress tracker is initialized at the beginning of the analyze and create 
functions. It is updated at significant milestones within the functions using the 
set_progress() method.

The progress bar relies on an approximate progress percentage rather than a fixed 
number of tasks. This approach allows for greater flexibility, but may be less 
precise than having a predetermined number of tasks. Be sure to adjust the progress 
updates in the code based on a good understanding of the overall process.
 
Motivation 
https://github.com/clowdhaus/eksup/issues/14

Resolves #

https://github.com/clowdhaus/eksup/issues/14

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
